### PR TITLE
DependencyControl support

### DIFF
--- a/DependencyControl.json
+++ b/DependencyControl.json
@@ -1,0 +1,71 @@
+{
+  "dependencyControlFeedFormatVersion": "0.1.0",
+  "name": "ASSInspector",
+  "description": "Official ASSInspector repository",
+  "baseUrl": "https://github.com/TypesettingCartel/ASSInspector",
+  "url": "@{baseUrl}",
+  "maintainer": "torque",
+  "modules": {
+    "ASSInspector.Inspector": {
+      "url": "@{baseUrl}",
+      "author": "torque",
+      "name": "ASSInspector",
+      "description": "Provides low level inspection and analysis of subtitles post-rasterization.",
+      "channels": {
+        "release": {
+          "version": "0.4.0",
+          "released": "2015-02-02",
+          "default": true,
+          "platforms": ["Windows-x86", "Windows-x64", "OSX-x64"],
+          "fileBaseUrl": "https://github.com/TypesettingCartel/ASSInspector/releases/download/v@{version}/@{name}",
+          "files": [
+            {
+              "name": ".moon",
+              "url": "https://raw.githubusercontent.com/TypesettingCartel/ASSInspector/v@{version}/examples/Aegisub@{fileName}",
+              "sha1": ""
+            },
+            {
+              "name": "/fonts.conf",
+              "url": "https://raw.githubusercontent.com/TypesettingCartel/ASSInspector/v@{version}/examples@{fileName}",
+              "sha1": "0505BEE4BF3C0A01515D4F253A5ED2535687362E"
+            },
+            {
+              "name": "/ASSInspector.dll",
+              "url": "@{fileBaseUrl}-win32.dll",
+              "platform": "Windows-x86",
+              "sha1": "7AFCE3FA6AC6A1A613C5974B6275770A6964EBD3"
+            },
+            {
+              "name": "/ASSInspector.dll",
+              "url": "@{fileBaseUrl}-win64.dll",
+              "platform": "Windows-x64",
+              "sha1": "D522672D1194F538C5AA563CF13E2F3244FAD169"
+            },
+            {
+              "name": "/libASSInspector.dylib",
+              "url": "@{fileBaseUrl}-osx-x86_64.dylib",
+              "platform": "OSX-x64",
+              "sha1": "AE9E5E9DC6D58AEEBCD48D0FA520E4B596167FC1"
+            }
+          ],
+          "requiredModules": [
+            {
+              "moduleName": "ffi"
+            }
+          ]
+        }
+      },
+      "changelog": {
+        "0.4.0": [
+          "Added solid field to ASSI_Rect.",
+        ],
+        "0.3.1": [
+          "Fixed hash reliability by not hashing junk memory."
+        ],
+        "0.3.0": [
+          "All inputs are hashed (CRC32) to provide a measure of uniqueness."
+        ]
+      }
+    },
+  }
+}

--- a/examples/Aegisub/Inspector.moon
+++ b/examples/Aegisub/Inspector.moon
@@ -1,15 +1,21 @@
 -- This library is unlicensed under CC0
 
+DependencyControl = require "l0.DependencyControl"
+
+versionRecord = DependencyControl{
+    name: "ASSInspector",
+    version: "0.4.0",
+    description: "Provides low level inspection and analysis of subtitles post-rasterization.",
+    author: "torque",
+    url: "https://github.com/TypesettingCartel/ASSInspector",
+    moduleName: "ASSInspector.Inspector",
+    feed: "https://raw.githubusercontent.com/TypesettingCartel/ASSInspector/master/DependencyControl.json",
+    {"ffi"}
+}
+
+ffi = versionRecord\requireModules!
+
 ASSIVersionCompat = 0x000400
-InspectorVersion  = 0x000400
-
-ffi = require( 'ffi' )
-bit = require( 'bit' )
-
-InspectorVersion_major = bit.rshift( ASSIVersionCompat, 16 )
-InspectorVersion_minor = bit.band( bit.rshift( ASSIVersionCompat, 8 ), 0xFF )
-InspectorVersion_patch = bit.band( ASSIVersionCompat, 0xFF )
-
 ASSIVersionCompat_major = bit.rshift( ASSIVersionCompat, 16 )
 ASSIVersionCompat_minor = bit.band( bit.rshift( ASSIVersionCompat, 8 ), 0xFF )
 ASSIVersionCompat_patch = bit.band( ASSIVersionCompat, 0xFF )
@@ -200,11 +206,8 @@ addStyles = ( line, scriptText, seenStyles ) =>
 				table.insert( scriptText, @styles[styleName] )
 				seenStyles[styleName] = true
 
-class Inspector
-	@version = InspectorVersion
-	@version_major = InspectorVersion_major
-	@version_minor = InspectorVersion_minor
-	@version_patch = InspectorVersion_patch
+class Inspectorversion_major
+	@version = versionRecord
 
 	new: ( subtitles, fontconfigConfig = aegisub.decode_path( libraryPath .. "/fonts.conf" ), fontDirectory = aegisub.decode_path( '?script/fonts' ) ) =>
 		assert subtitles, "You must provide the subtitles object."
@@ -326,4 +329,4 @@ class Inspector
 
 		return rects, times
 
-return Inspector
+return versionRecord\register Inspector

--- a/examples/Aegisub/Inspector.moon
+++ b/examples/Aegisub/Inspector.moon
@@ -12,13 +12,9 @@ versionRecord = DependencyControl{
     feed: "https://raw.githubusercontent.com/TypesettingCartel/ASSInspector/master/DependencyControl.json",
     {"ffi"}
 }
+ASSIVersionCompat = DependencyControl moduleName: "ASSInspector.Compat", version: "0.4.0", virtual: true
 
 ffi = versionRecord\requireModules!
-
-ASSIVersionCompat = 0x000400
-ASSIVersionCompat_major = bit.rshift( ASSIVersionCompat, 16 )
-ASSIVersionCompat_minor = bit.band( bit.rshift( ASSIVersionCompat, 8 ), 0xFF )
-ASSIVersionCompat_patch = bit.band( ASSIVersionCompat, 0xFF )
 
 ffi.cdef( [[
 typedef struct {
@@ -52,14 +48,11 @@ if not success
 -- Returns true if the versions are compatible and nil, "message" if
 -- they aren't.
 looseVersionCompare = ( ASSIVersion ) ->
-	ASSIVersion_major = bit.rshift( ASSIVersion, 16 )
-	ASSIVersion_minor = bit.band( bit.rshift( ASSIVersion, 8 ), 0xFF )
-	ASSIVersion_patch = bit.band( ASSIVersion, 0xFF )
-
-	if ASSIVersion_major > ASSIVersionCompat_major
-		return nil, ("Inspector.moon library is too old. Must be v%d.x.x")\format ASSIVersionCompat_major
-	elseif ASSIVersion_major < ASSIVersionCompat_major or ASSIVersion_minor < ASSIVersionCompat_minor
-		return nil, ("libASSInspector library is too old. Must be v%d.%d.x compatible.")\format ASSIVersionCompat_major, ASSIVersionCompat_minor
+	assiVer = DependencyControl moduleName: "ASSInspector.Lib", version: ASSIVersion, virtual: true
+	unless ASSIVersionCompat\checkVersion assiVer, "major"
+		return nil, ("Inspector.moon library is too old. Must be v%s.")\format assiVer\getVersionString nil, "major"
+	unless assiVer\checkVersion ASSIVersionCompat, "minor"
+		return nil, ("libASSInspector library is too old. Must be v%s compatible.")\format ASSIVersionCompat\getVersionString nil, "minor"
 
 	return true
 
@@ -206,7 +199,7 @@ addStyles = ( line, scriptText, seenStyles ) =>
 				table.insert( scriptText, @styles[styleName] )
 				seenStyles[styleName] = true
 
-class Inspectorversion_major
+class Inspector
 	@version = versionRecord
 
 	new: ( subtitles, fontconfigConfig = aegisub.decode_path( libraryPath .. "/fonts.conf" ), fontDirectory = aegisub.decode_path( '?script/fonts' ) ) =>


### PR DESCRIPTION
adds DependencyControl to ASSInspector.
Inspector.moon SHA-1 left blank because of pending changes.
100% untested.
